### PR TITLE
fix: swap confirm modal doesn't dismiss

### DIFF
--- a/src/pages/Swap/Swap/index.vue
+++ b/src/pages/Swap/Swap/index.vue
@@ -54,7 +54,7 @@
       </div>
     </div>
   </Page>
-  <ConfirmModal :show="swapState.showConfirm" :trade="tradeToConfirm" @swap="handleSwap" />
+  <ConfirmModal :show="swapState.showConfirm" :trade="tradeToConfirm" @swap="handleSwap" @dismiss="swapState.showConfirm = false" />
   <WaittingModal :show="swapState.attemptingTxn" :desc="summary" @dismiss="swapState.attemptingTxn = false" />
   <RejectedModal :show="showRejectedModal" @dismiss="onReset" />
   <ScuccessModal :show="!!swapState.txHash" :tx="swapState.txHash" @dismiss="onReset" />


### PR DESCRIPTION
### Description
Swap confirm modal doesn't dismiss

### Steps to reproduce
1. Click 'x' or area outside the modal window

### What is the current *bug* behavior?
confirm modal doesn't dismiss

### What is the expected *correct* behavior?
confirm modal should dismiss

### Screenshots
![image](https://github.com/10k-swap/10k_swap-frontend/assets/31704887/0908e219-2fba-42ae-951c-6e1b3f755354)
